### PR TITLE
DRY things up

### DIFF
--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -20,28 +20,21 @@ from cliff.lister import Lister
 from cliff.show import ShowOne
 from ara import app, db, models, utils
 
+FIELDS = (
+    ('ID',),
+    ('Path',),
+    ('Time Start',),
+    ('Time End',),
+)
+
 
 class PlaybookList(Lister):
     """Returns a list of playbooks"""
     log = logging.getLogger(__name__)
 
-    def get_parser(self, prog_name):
-        parser = super(PlaybookList, self).get_parser(prog_name)
-        return parser
-
     def take_action(self, parsed_args):
         playbooks = models.Playbook.query.all()
-
-        fields = (
-            ('ID',),
-            ('Path',),
-            ('Time Start',),
-            ('Time End',),
-        )
-
-        return ([field[0] for field in fields],
-                [[utils.get_field_attr(playbook, field)
-                  for field in fields] for playbook in playbooks])
+        return utils.fields_from_iter(FIELDS, playbooks)
 
 
 class PlaybookShow(ShowOne):
@@ -59,12 +52,4 @@ class PlaybookShow(ShowOne):
 
     def take_action(self, parsed_args):
         playbook = models.Playbook.query.get(parsed_args.playbook_id)
-
-        data = {
-            'ID': playbook.id,
-            'Path': playbook.path,
-            'Time Start': playbook.time_start,
-            'Time End': playbook.time_end
-        }
-
-        return zip(*sorted(six.iteritems(data)))
+        return utils.fields_from_object(FIELDS, playbook)

--- a/ara/utils.py
+++ b/ara/utils.py
@@ -19,21 +19,6 @@ from ara import app, models, db
 from flask import url_for, Markup
 
 
-# Jinja filters
-@app.template_filter('datetime')
-def jinja_date_formatter(timestamp, format='%Y-%m-%d-%H:%M:%S.%f'):
-    """ Reformats a datetime timestamp from str(datetime.datetime)"""
-    datetime_format = "%Y-%m-%d %H:%M:%S.%f"
-    timestamp = datetime.datetime.strptime(timestamp, datetime_format)
-    return timestamp.strftime(format)[:-3]
-
-
-@app.template_filter('seconds_to_duration')
-def jinja_seconds_to_duration(seconds):
-    """ Reformats an amount of seconds for friendly output"""
-    return str(datetime.timedelta(seconds=float(seconds)))[:-3]
-
-
 @app.template_filter('to_nice_json')
 def jinja_to_nice_json(result):
     """ Formats a result """
@@ -67,12 +52,17 @@ def make_link(view, label, **kwargs):
 
 
 @app.context_processor
-def add_markup_to_context():
+def ctx_add_utility_functions():
+    '''Adds some utility functions to the template context.'''
+
     return dict(make_link=make_link)
 
 
 @app.context_processor
-def add_nav_data():
+def ctx_add_nav_data():
+    '''Makes some standard data from the database available in the
+    template context.'''
+
     playbook_item_limit = app.config.get('NAV_MENU_MAX_PLAYBOOKS', 10)
     host_item_limit = app.config.get('NAV_MENU_MAX_HOSTS', 10)
 
@@ -96,6 +86,51 @@ def default_data():
     }
 
     return data
+
+
+def fields_from_iter(fields, items, xforms=None):
+    '''Returns column headers and data for use by
+    `cliff.lister.Lister`.  In this function and in
+    `fields_from_object`, fields are specified as a list of
+    `(column_name, object_path)` tuples.  The `object_path` can be
+    omitted if it can be inferred from the column name by converting
+    the name to lowercase and converting ' ' to '_'.  For example:
+
+        fields = (
+            ('ID',),
+            ('Name',),
+            ('Playbook',),
+        )
+
+    The `xforms` parameter is a dictionary maps column names to
+    callables that will be used to format the corresponding value.
+    For example:
+
+        xforms = {
+            'Playbook': lambda p: p.name,
+        }
+    '''
+
+    xforms = xforms or {}
+
+    return (zip(*fields)[0], [
+        [xform(v) for v, xform in
+         [(get_field_attr(item, f[0]), f[1]) for f in
+          [(field, xforms.get(field[0], lambda x: x)) for field in fields]]]
+        for item in items])
+
+
+def fields_from_object(fields, obj, xforms=None):
+    '''Returns labels and values for use by `cliff.show.ShowOne`.  See
+    the documentation for `fields_from_iter` for details.'''
+
+    xforms = xforms or {}
+
+    return (zip(*fields)[0],
+            [xform(v) for v, xform in
+             [(get_field_attr(obj, f[0]), f[1]) for f in
+              [(field, xforms.get(field[0], lambda x: x))
+               for field in fields]]])
 
 
 def status_to_query(status=None):
@@ -145,9 +180,21 @@ def get_stats_for_playbooks(playbook_uuids, **kwargs):
 
 
 def get_field_attr(obj, field):
-    if len(field) > 1:
-        attribute = field[1]
-    else:
-        attribute = field[0].lower().replace(' ', '_')
+    '''Returns the value of an attribute path applied to an object.
+    The attribute path is either made available explicitly as
+    `field[1]` or implicitly by converting `field[0]` to lower case
+    and converting ' ' to '_'.  In other words, given:
 
-    return reduce(getattr, attribute.split('.'), obj)
+        field = ('Name',)
+
+    `get_field_attribute(obj, field)` would return the value of the
+    `name` attribute of `obj`.  On other hand, given:
+
+        field = ('Name', 'playbook.name')
+
+    `get_field_attribute(obj, field)` would return the value of the
+    `name` attribute of the `playbook` attribute of `obj`.
+    '''
+
+    path = field[-1].lower().replace(' ', '_').split('.')
+    return reduce(getattr, path, obj)


### PR DESCRIPTION
This change removes a lot of boilerplate and dead code through
utils.py and the cli modules.  A key change in the cli modules is that
we can re-use the definition of `fields` from the list action in the
show action, thereby ensuring that related commands return consistent
information.