### PR TITLE
better __repr__ methods for models

### DIFF
--- a/ara/models.py
+++ b/ara/models.py
@@ -74,7 +74,7 @@ class Playbook(db.Model, TimedEntity):
     time_end = db.Column(db.DateTime)
 
     def __repr__(self):
-        return '<Playbook %r>' % self.path
+        return '<Playbook %s>' % self.path
 
 
 class Play(db.Model, TimedEntity):
@@ -97,6 +97,9 @@ class Play(db.Model, TimedEntity):
 
     time_start = db.Column(db.DateTime, default=datetime.now)
     time_end = db.Column(db.DateTime)
+
+    def __repr__(self):
+        return '<Play %s>' % (self.name or self.id)
 
 
 class Task(db.Model, TimedEntity):
@@ -133,7 +136,7 @@ class Task(db.Model, TimedEntity):
                                    lazy='dynamic')
 
     def __repr__(self):
-        return '<Task %r>' % self.name
+        return '<Task %s>' % (self.name or self.id)
 
 
 class TaskResult(db.Model, TimedEntity):
@@ -166,7 +169,8 @@ class TaskResult(db.Model, TimedEntity):
     time_end = db.Column(db.DateTime)
 
     def __repr__(self):
-        return '<TaskResult %r>' % self.host
+        return '<TaskResult %s>' % self.host.name
+
 
 host_playbook = db.Table(
     'host_playbook',
@@ -201,6 +205,9 @@ class Host(db.Model):
     playbooks = db.relationship('Playbook', secondary=host_playbook,
                                 backref='hosts', lazy='dynamic')
 
+    def __repr__(self):
+        return '<Host %s>' % self.name
+
 
 class Stats(db.Model):
     '''A `Stats` object contains statistics for a single host from a
@@ -228,4 +235,4 @@ class Stats(db.Model):
     unreachable = db.Column(db.Integer)
 
     def __repr__(self):
-        return '<Stats %r>' % self.host
+        return '<Stats for %s>' % self.host.name


### PR DESCRIPTION
This makes the `__repr__` methods in `models.py` return something that
I find more helpful during development.  With this in place, you get:

    >>> models.Playbook.query.first()
    <Playbook multihost.yml>
    >>> models.Task.query.first()
    <Task task 1>
    >>> models.Stats.query.first()
    <Stats for host2>