### PR TITLE
Implement status filtering from the statistics table

### DIFF
--- a/ara/static/css/ara.css
+++ b/ara/static/css/ara.css
@@ -40,6 +40,7 @@ ol.breadcrumb {
 td a {
     width:100%;
     display:block;
+    font-weight: bold;
 }
 
 .summary table, .summary th, .summary td {

--- a/ara/templates/host.html
+++ b/ara/templates/host.html
@@ -21,13 +21,13 @@
       {% for playbook in host.playbooks %}
       {% set stats = host.stats.filter_by(playbook_id=playbook.id).one() %}
       <tr>
-        <td>{{ make_link('playbook_host', playbook.path, host=host.name, playbook=playbook.id) }}</td>
+        <td>{{ macros.make_link('playbook_host', playbook.path, host=host.name, playbook=playbook.id) }}</td>
         <td>{{ playbook.time_start |datetime }}</td>
-        <td>{{ stats.ok }}</td>
-        <td>{{ stats.changed }}</td>
-        <td>{{ stats.failed }}</td>
-        <td>{{ stats.skipped }}</td>
-        <td>{{ stats.unreachable }}</td>
+        {{ macros.statslink(stats, 'ok', playbook, host) }}
+        {{ macros.statslink(stats, 'changed', playbook, host) }}
+        {{ macros.statslink(stats, 'failed', playbook, host) }}
+        {{ macros.statslink(stats, 'skipped', playbook, host) }}
+        {{ macros.statslink(stats, 'unreachable', playbook, host) }}
       </tr>
     {% endfor %}
   </tbody>

--- a/ara/templates/host_summary.html
+++ b/ara/templates/host_summary.html
@@ -16,12 +16,12 @@
   <tbody>
       {% for host in hosts %}
       <tr>
-        <td>{{ make_link('host', host.name, host=host.name) }}</td>
-        <td>{{ stats[host.id]['ok'] }}</td>
-        <td>{{ stats[host.id]['changed'] }}</td>
-        <td>{{ stats[host.id]['failed'] }}</td>
-        <td>{{ stats[host.id]['skipped'] }}</td>
-        <td>{{ stats[host.id]['unreachable'] }}</td>
+        <td>{{ macros.make_link('host', host.name, host=host.name) }}</td>
+        <td>{{ stats[host.id].ok }}</td>
+        <td>{{ stats[host.id].changed }}</td>
+        <td>{{ stats[host.id].failed }}</td>
+        <td>{{ stats[host.id].skipped }}</td>
+        <td>{{ stats[host.id].unreachable }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/ara/templates/layout.html
+++ b/ara/templates/layout.html
@@ -1,4 +1,7 @@
 <!DOCTYPE html>
+
+{% import "macros.html" as macros %}
+
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/ara/templates/macros.html
+++ b/ara/templates/macros.html
@@ -1,0 +1,17 @@
+<div id="macros">
+{% macro make_link(view, label) %}
+<a href="{{ url_for(view, **kwargs) }}">{{label}}</a>
+{% endmacro %}
+
+
+{% macro statslink(stats, stat, playbook, host) %}
+<td>
+{% if stats[stat] >= 1 -%}
+{{ make_link('playbook_host', stats[stat],
+   playbook=playbook.id, host=host.name, status=stat) }}
+{% else -%}
+0
+{% endif %}
+</td>
+{% endmacro %}
+</div>

--- a/ara/templates/play.html
+++ b/ara/templates/play.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 <ol class="breadcrumb">
-  <li>{{ make_link('playbook', 'Playbook', playbook=play.playbook.id) }}</li>
+  <li>{{ macros.make_link('playbook', 'Playbook', playbook=play.playbook.id) }}</li>
   <li class="active"><strong>Play</strong>{% if play.name %}: "{{play.name}}"{% endif %}</li>
 </ol>
 
@@ -48,7 +48,7 @@
     <td>{{ task.action }}</td>
     <td>{{ task.path }}</td>
     <td>{{ task.lineno }}</td>
-    <td>{{ make_link('task', 'details', task=task.id) }}</td>
+    <td>{{ macros.make_link('task', 'details', task=task.id) }}</td>
   </tr>
   {% endfor %}
   </tbody>

--- a/ara/templates/playbook.html
+++ b/ara/templates/playbook.html
@@ -38,12 +38,12 @@
   <tbody>
     {% for stat in playbook.stats %}
     <tr>
-      <td>{{ make_link('playbook_host', stat.host.name, playbook=playbook.id, host=stat.host.name) }}</td>
-      <td>{{ stat.ok }}</td>
-      <td>{{ stat.changed }}</td>
-      <td>{{ stat.failed }}</td>
-      <td>{{ stat.skipped }}</td>
-      <td>{{ stat.unreachable }}</td>
+      <td>{{ macros.make_link('playbook_host', stat.host.name, playbook=playbook.id, host=stat.host.name) }}</td>
+        {{ macros.statslink(stat, 'ok', playbook, stat.host) }}
+        {{ macros.statslink(stat, 'changed', playbook, stat.host) }}
+        {{ macros.statslink(stat, 'failed', playbook, stat.host) }}
+        {{ macros.statslink(stat, 'skipped', playbook, stat.host) }}
+        {{ macros.statslink(stat, 'unreachable', playbook, stat.host) }}
     </tr>
     {% endfor %}
   </tbody>
@@ -66,7 +66,7 @@
       <td>{{ playbook.time_start |datetime }}</td>
       <td>{{ playbook.time_end |datetime }}</td>
       <td>{{ playbook.duration }}</td>
-      <td>{{ make_link('play', 'details', play=play.id) }}</td>
+      <td>{{ macros.make_link('play', 'details', play=play.id) }}</td>
     </tr>
     {% endfor %}
   </tbody>
@@ -95,7 +95,7 @@
       <td>{{ task.action }}</td>
       <td>{{ task.path }}</td>
       <td>{{ task.lineno }}</td>
-      <td>{{ make_link('task', 'details', task=task.id) }}
+      <td>{{ macros.make_link('task', 'details', task=task.id) }}
       </td>
     </tr>
     {% endfor %}

--- a/ara/templates/playbook_host.html
+++ b/ara/templates/playbook_host.html
@@ -2,8 +2,13 @@
 
 {% block content %}
 <ol class="breadcrumb">
-  <li>{{ make_link('playbook', 'Playbook', playbook=playbook.id) }}</li>
+  <li>{{ macros.make_link('playbook', 'Playbook', playbook=playbook.id) }}</li>
+  {% if status %}
+  <li>{{ macros.make_link('host', host.name, host=host.name) }}</li>
+  <li class="active"><strong>Status</strong>: {{ status }}</li>
+  {% else %}
   <li class="active"><strong>Host</strong>: {{ host.name }}</li>
+  {% endif %}
 </ol>
 
 <h2>Tasks in playbook {% if playbook.path %}"{{ playbook.path }}"
@@ -29,11 +34,11 @@
         <td>{{ result.time_start |datetime }}</td>
         <td>{{ result.time_end |datetime }}</td>
         <td>{{ result.duration }}</td>
-        <td>{{ make_link('host', result.host.name, host=result.host.name) }}</td>
+        <td>{{ macros.make_link('host', result.host.name, host=result.host.name) }}</td>
         <td>{{ result.task.name }}</td>
         <td>{{ result.task.action }}</td>
         <td>{{ result|pick_status }}</td>
-        <td>{{ make_link('task_result', 'details', task_result=result.id) }}</td>
+        <td>{{ macros.make_link('task_result', 'details', task_result=result.id) }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/ara/templates/playbook_summary.html
+++ b/ara/templates/playbook_summary.html
@@ -17,13 +17,13 @@
   <tbody>
       {% for playbook in playbooks.order_by('time_start') %}
       <tr>
-        <td>{{ make_link('playbook', '%s' % playbook.path, playbook=playbook.id) }}</td>
+        <td>{{ macros.make_link('playbook', '%s' % playbook.path, playbook=playbook.id) }}</td>
         <td>{{ playbook.time_start |datetime }}</td>
-        <td>{{ stats[playbook.id]['ok'] }}</td>
-        <td>{{ stats[playbook.id]['changed'] }}</td>
-        <td>{{ stats[playbook.id]['failed'] }}</td>
-        <td>{{ stats[playbook.id]['skipped'] }}</td>
-        <td>{{ stats[playbook.id]['unreachable'] }}</td>
+        <td>{{ stats[playbook.id].ok }}</td>
+        <td>{{ stats[playbook.id].changed }}</td>
+        <td>{{ stats[playbook.id].failed }}</td>
+        <td>{{ stats[playbook.id].skipped }}</td>
+        <td>{{ stats[playbook.id].unreachable }}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/ara/templates/task.html
+++ b/ara/templates/task.html
@@ -2,8 +2,8 @@
 
 {% block content %}
 <ol class="breadcrumb">
-  <li>{{ make_link('playbook', 'Playbook', playbook=task.playbook.id) }}</li>
-  <li>{{ make_link('play', 'Play', play=task.play.id) }}</li>
+  <li>{{ macros.make_link('playbook', 'Playbook', playbook=task.playbook.id) }}</li>
+  <li>{{ macros.make_link('play', 'Play', play=task.play.id) }}</li>
   <li class="active"><strong>Task</strong>{% if task.name %}: "{{task.name}}"{% endif %}</li>
 </ol>
 
@@ -51,9 +51,9 @@
       <td>{{ result.time_start |datetime }}</td>
       <td>{{ result.time_end |datetime }}</td>
       <td>{{ result.duration }}</td>
-      <td>{{ make_link('host', result.host.name, host=result.host.name) }}</td>
+      <td>{{ macros.make_link('host', result.host.name, host=result.host.name) }}</td>
       <td>{{ result|pick_status }}</td>
-      <td>{{ make_link('task_result', 'details', task_result=result.id) }}</td>
+      <td>{{ macros.make_link('task_result', 'details', task_result=result.id) }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/ara/templates/task_result.html
+++ b/ara/templates/task_result.html
@@ -2,9 +2,9 @@
 
 {% block content %}
 <ol class="breadcrumb">
-  <li>{{ make_link('playbook', 'Playbook', playbook=task_result.task.playbook.id) }}</li>
-  <li>{{ make_link('play', 'Play', play=task_result.task.play.id) }}</li>
-  <li>{{ make_link('task', 'Task', task=task_result.task.id) }}</li>
+  <li>{{ macros.make_link('playbook', 'Playbook', playbook=task_result.task.playbook.id) }}</li>
+  <li>{{ macros.make_link('play', 'Play', play=task_result.task.play.id) }}</li>
+  <li>{{ macros.make_link('task', 'Task', task=task_result.task.id) }}</li>
   <li class="active"><strong>Host</strong>: {{ task_result.host.name }}</li>
 </ol>
 

--- a/ara/utils.py
+++ b/ara/utils.py
@@ -51,19 +51,6 @@ def jinja_pick_status(row):
     return 'ok'
 
 
-def make_link(view, label, **kwargs):
-    return Markup('<a href="{}">{}</a>'.format(
-        url_for(view, **kwargs),
-        label))
-
-
-@app.context_processor
-def ctx_add_utility_functions():
-    '''Adds some utility functions to the template context.'''
-
-    return dict(make_link=make_link)
-
-
 @app.context_processor
 def ctx_add_nav_data():
     '''Makes some standard data from the database available in the
@@ -139,28 +126,26 @@ def fields_from_object(fields, obj, xforms=None):
                for field in fields]]])
 
 
-def status_to_query(status=None):
+def status_to_query(status):
     """
-    Returns a dict based on status
+    Returns a dict to be used as filter kwargs based on status
     """
-    if status is not None:
-        return {
-            'ok': {
-                'changed': False,
-                'failed': False,
-                'skipped': False
-            },
-            'changed': {'changed': True},
-            'ignored': {
-                'failed': True,
-                'ignore_errors': True
-            },
-            'failed': {'failed': True},
-            'skipped': {'skipped': True},
-            'unreachable': {'unreachable': True}
-        }[status]
-    else:
-        return None
+    return {
+        'ok': {
+            'changed': False,
+            'failed': False,
+            'skipped': False,
+            'unreachable': False
+        },
+        'changed': {'changed': True},
+        'ignored': {
+            'failed': True,
+            'ignore_errors': True
+        },
+        'failed': {'failed': True},
+        'skipped': {'skipped': True},
+        'unreachable': {'unreachable': True}
+    }[status]
 
 
 def get_summary_stats(items, attr):

--- a/ara/views.py
+++ b/ara/views.py
@@ -16,7 +16,6 @@ from flask import render_template
 from ara import app, models, utils
 
 
-# Routes
 @app.route('/')
 def main():
     """ Returns the home page """
@@ -74,10 +73,18 @@ def playbook(playbook):
 
 
 @app.route('/playbook/<playbook>/host/<host>')
-def playbook_host(playbook, host):
+@app.route('/playbook/<playbook>/host/<host>/status/<status>')
+def playbook_host(playbook, host, status=None):
     host = models.Host.query.filter_by(name=host).one()
     playbook = models.Playbook.query.get(playbook)
-    task_results = (models.TaskResult.query
+
+    task_results = models.TaskResult.query
+
+    if status is not None:
+        status_query = utils.status_to_query(status)
+        task_results = task_results.filter_by(**status_query)
+
+    task_results = (task_results
                     .join(models.Task)
                     .join(models.Host)
                     .join(models.Playbook)
@@ -87,4 +94,5 @@ def playbook_host(playbook, host):
     return render_template('playbook_host.html',
                            playbook=playbook,
                            host=host,
-                           task_results=task_results)
+                           task_results=task_results,
+                           status=status)


### PR DESCRIPTION
This modifies #31 to use Jinja2 macros for generating the conditional links.
It also moves `make_link()` out of `utils.py` and into a macro (partly
because this seems like the right thing to do for a function that is primarily
generating HTML, but also because variable scoping issues seemed to result
in `make_link` being unavailable inside a macroc ontext).