### PR TITLE
Bump result field to mediumtext and handle larger than that

### DIFF
--- a/ara/models.py
+++ b/ara/models.py
@@ -163,7 +163,7 @@ class TaskResult(db.Model, TimedEntity):
     skipped = db.Column(db.Boolean)
     unreachable = db.Column(db.Boolean)
     ignore_errors = db.Column(db.Boolean)
-    result = db.Column(db.Text)
+    result = db.Column(db.Text(16777215))
 
     time_start = db.Column(db.DateTime, default=datetime.now)
     time_end = db.Column(db.DateTime)

--- a/ara/utils.py
+++ b/ara/utils.py
@@ -17,7 +17,7 @@ import datetime
 import json
 
 from flask import url_for, Markup
-from ara import app, models, db
+from ara import app, models, db, LOG
 from ara.config import ARA_PATH_MAX
 
 
@@ -36,7 +36,11 @@ def jinja_to_nice_json(result):
 
 @app.template_filter('from_json')
 def jinja_from_json(val):
-    return json.loads(val)
+    try:
+        return json.loads(val)
+    except Exception as e:
+        LOG.error('Unable to load json: %s' % str(e))
+        return val
 
 
 @app.template_filter('pick_status')


### PR DESCRIPTION
Text has a maximum length of 65,535.
MediumText has a maximum length of 16,777,215.

Realistically, we should never go over MediumText but if that
happens, catch it.