### PR TITLE
display task start time as offset from play or playbook

### DIFF
--- a/ara/models.py
+++ b/ara/models.py
@@ -103,6 +103,10 @@ class Play(db.Model, TimedEntity):
     def __repr__(self):
         return '<Play %s>' % (self.name or self.id)
 
+    @property
+    def offset_from_playbook(self):
+        return self.time_start - self.playbook.time_start
+
 
 class Task(db.Model, TimedEntity):
     '''The `Task` class represents a single task defined in an Ansible
@@ -140,6 +144,14 @@ class Task(db.Model, TimedEntity):
 
     def __repr__(self):
         return '<Task %s>' % (self.name or self.id)
+
+    @property
+    def offset_from_playbook(self):
+        return self.time_start - self.playbook.time_start
+
+    @property
+    def offset_from_play(self):
+        return self.time_start - self.play.time_start
 
 
 class TaskResult(db.Model, TimedEntity):

--- a/ara/templates/host.html
+++ b/ara/templates/host.html
@@ -23,7 +23,7 @@
       <tr>
         <td>{{ macros.make_link('playbook_host',
           playbook.path|pathtruncate, host=host.name, playbook=playbook.id) }}</td>
-        <td>{{ playbook.time_start |datetime }}</td>
+        <td>{{ playbook.time_start |datefmt }}</td>
         {{ macros.statslink(stats, 'ok', playbook, host) }}
         {{ macros.statslink(stats, 'changed', playbook, host) }}
         {{ macros.statslink(stats, 'failed', playbook, host) }}

--- a/ara/templates/navbar.html
+++ b/ara/templates/navbar.html
@@ -26,7 +26,7 @@
           <ul class="dropdown-menu">
             {% for playbook in playbooks %}
             <li><a href="/playbook/{{ playbook.id
-            }}">{{ playbook.path|pathtruncate }} @ {{ playbook.time_start |datetime }}</a></li>
+            }}">{{ playbook.path|pathtruncate }} @ {{ playbook.time_start |datefmt }}</a></li>
             {% endfor %}
             <li><a href="/playbook">All playbooks...</a></li>
           </ul>

--- a/ara/templates/play.html
+++ b/ara/templates/play.html
@@ -18,9 +18,9 @@
 
   <tbody>
     <tr>
-      <td>{{ play.time_start |datetime }}</td>
-      <td>{{ play.time_end |datetime }}</td>
-      <td>{{ play.duration }}</td>
+      <td>{{ play.time_start |datefmt }}</td>
+      <td>{{ play.time_end |datefmt }}</td>
+      <td>{{ play.duration |timefmt }}</td>
     </tr>
   </tbody>
 </table>
@@ -29,8 +29,7 @@
 <table class="tasks table table-striped table-bordered table-hover table-condensed">
   <thead>
     <tr>
-      <th>Start</th>
-      <th>End</th>
+      <th>Offset from play</th>
       <th>Duration</th>
       <th>Action</th>
       <th>File</th>
@@ -42,9 +41,8 @@
   <tbody>
   {% for task in play.tasks.order_by('sortkey') %}
   <tr>
-    <td>{{ task.time_start |datetime }}</td>
-    <td>{{ task.time_end |datetime }}</td>
-    <td>{{ task.duration }}</td>
+    <td>{{ task.offset_from_play |timefmt }}</td>
+    <td>{{ task.duration |timefmt }}</td>
     <td>{{ task.action }}</td>
     <td>{{ task.path|pathtruncate }}</td>
     <td>{{ task.lineno }}</td>

--- a/ara/templates/playbook.html
+++ b/ara/templates/playbook.html
@@ -6,7 +6,9 @@
     "{{playbook.path}}"{% endif %}</li>
 </ol>
 
-<h2>Playbook information</h2>
+<h2>Playbook {% if playbook.path %}"{{
+  playbook.path|pathtruncate }}"
+  {% else %}{{playbook.id}}{% endif %}</h2>
 <table class="summary table table-striped table-bordered table-hover table-condensed">
   <thead>
     <tr>
@@ -17,9 +19,9 @@
   </thead>
   <tbody>
     <tr>
-      <td>{{ playbook.time_start |datetime }}</td>
-      <td>{{ playbook.time_end |datetime }}</td>
-      <td>{{ playbook.duration }}</td>
+      <td>{{ playbook.time_start |datefmt }}</td>
+      <td>{{ playbook.time_end |datefmt }}</td>
+      <td>{{ playbook.duration |timefmt }}</td>
     </tr>
   </tbody>
 </table>
@@ -64,9 +66,9 @@
   <tbody>
     {% for play in playbook.plays.order_by('sortkey') %}
     <tr>
-      <td>{{ playbook.time_start |datetime }}</td>
-      <td>{{ playbook.time_end |datetime }}</td>
-      <td>{{ playbook.duration }}</td>
+      <td>{{ playbook.time_start |datefmt }}</td>
+      <td>{{ playbook.time_end |datefmt }}</td>
+      <td>{{ playbook.duration |timefmt }}</td>
       <td>{{ macros.make_link('play', 'details', play=play.id) }}</td>
     </tr>
     {% endfor %}
@@ -77,8 +79,7 @@
 <table class="tasks table table-striped table-bordered table-hover table-condensed">
   <thead>
     <tr>
-      <th>Start</th>
-      <th>End</th>
+      <th>Offset from Playbook</th>
       <th>Duration</th>
       <th>Action</th>
       <th>File</th>
@@ -90,9 +91,8 @@
   <tbody>
     {% for task in playbook.tasks.order_by('sortkey') %}
     <tr>
-      <td>{{ task.time_start |datetime }}</td>
-      <td>{{ task.time_end |datetime }}</td>
-      <td>{{ task.duration }}</td>
+      <td>{{ task.offset_from_playbook |timefmt }}</td>
+      <td>{{ task.duration |timefmt }}</td>
       <td>{{ task.action }}</td>
       <td>{{ task.path|pathtruncate }}</td>
       <td>{{ task.lineno }}</td>

--- a/ara/templates/playbook_host.html
+++ b/ara/templates/playbook_host.html
@@ -11,7 +11,27 @@
   {% endif %}
 </ol>
 
-<h2>Tasks in playbook {% if playbook.path %}"{{
+<h2>Playbook {% if playbook.path %}"{{
+  playbook.path|pathtruncate }}"
+  {% else %}{{playbook.id}}{% endif %}</h2>
+<table class="summary table table-striped table-bordered table-hover table-condensed">
+  <thead>
+    <tr>
+      <th>Start</th>
+      <th>End</th>
+      <th>Duration</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>{{ playbook.time_start |datefmt }}</td>
+      <td>{{ playbook.time_end |datefmt }}</td>
+      <td>{{ playbook.duration |timefmt}}</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Tasks results in playbook {% if playbook.path %}"{{
   playbook.path|pathtruncate }}"
   {% else %}{{playbook.id}}{% endif %} for {{ host.name }}</h2>
 
@@ -19,8 +39,7 @@
   <table class="results table table-striped table-bordered table-hover table-condensed">
     <thead>
       <tr>
-        <th>Start</th>
-        <th>End</th>
+        <th>Offset from playbook</th>
         <th>Duration</th>
         <th>Host</th>
         <th>Task</th>
@@ -33,9 +52,8 @@
       {% for result in task_results %}
       {% set status = result.derived_status %}
       <tr>
-        <td>{{ result.time_start |datetime }}</td>
-        <td>{{ result.time_end |datetime }}</td>
-        <td>{{ result.duration }}</td>
+        <td>{{ result.task.offset_from_playbook|timefmt }}</td>
+        <td>{{ result.duration |timefmt }}</td>
         <td>{{ macros.make_link('host', result.host.name, host=result.host.name) }}</td>
         <td>{{ result.task.name }}</td>
         <td>{{ result.task.action }}</td>

--- a/ara/templates/playbook_summary.html
+++ b/ara/templates/playbook_summary.html
@@ -19,7 +19,7 @@
       <tr>
         <td>{{ macros.make_link('playbook', playbook.path|pathtruncate,
           playbook=playbook.id) }}</td>
-        <td>{{ playbook.time_start |datetime }}</td>
+        <td>{{ playbook.time_start |datefmt }}</td>
         <td>{{ stats[playbook.id].ok }}</td>
         <td>{{ stats[playbook.id].changed }}</td>
         <td>{{ stats[playbook.id].failed }}</td>

--- a/ara/templates/task.html
+++ b/ara/templates/task.html
@@ -22,9 +22,9 @@
 
   <tbody>
     <tr>
-      <td>{{ task.time_start |datetime }}</td>
-      <td>{{ task.time_end |datetime }}</td>
-      <td>{{ task.duration }}</td>
+      <td>{{ task.time_start |datefmt }}</td>
+      <td>{{ task.time_end |datefmt }}</td>
+      <td>{{ task.duration |timefmt }}</td>
       <td>{{ task.action }}</td>
       <td>{{ task.path|pathtruncate }}</td>
       <td>{{ task.lineno }}</td>
@@ -49,9 +49,9 @@
     {% for result in task.task_results.order_by('time_start') %}
     {% set status = result.derived_status %}
     <tr>
-      <td>{{ result.time_start |datetime }}</td>
-      <td>{{ result.time_end |datetime }}</td>
-      <td>{{ result.duration }}</td>
+      <td>{{ result.time_start |datefmt }}</td>
+      <td>{{ result.time_end |datefmt }}</td>
+      <td>{{ result.duration |timefmt }}</td>
       <td>{{ macros.make_link('host', result.host.name, host=result.host.name) }}</td>
       <td><span class="{{ status }} label status-label">{{ status |upper }}</span></td>
       <td>{{ macros.make_link('task_result', 'details', task_result=result.id) }}</td>

--- a/ara/templates/task_result.html
+++ b/ara/templates/task_result.html
@@ -48,9 +48,9 @@
 
   <tbody>
     <tr>
-      <td>{{ task_result.time_start |datetime }}</td>
-      <td>{{ task_result.time_end |datetime }}</td>
-      <td>{{ task_result.duration }}</td>
+      <td>{{ task_result.time_start |datefmt }}</td>
+      <td>{{ task_result.time_end |datefmt }}</td>
+      <td>{{ task_result.duration |timefmt }}</td>
       <td>{{ task_result.task.action }}</td>
       <td>{{ task_result.task.path|pathtruncate }}</td>
       <td>{{ task_result.task.lineno }}</td>

--- a/ara/utils.py
+++ b/ara/utils.py
@@ -21,10 +21,17 @@ from ara import app, models, db, LOG
 from ara.config import ARA_PATH_MAX
 
 
-@app.template_filter('datetime')
+@app.template_filter('datefmt')
 def jinja_date_formatter(timestamp, format='%Y-%m-%d %H:%M:%S'):
     """ Reformats a datetime timestamp from str(datetime.datetime)"""
     return datetime.datetime.strftime(timestamp, format)
+
+
+@app.template_filter('timefmt')
+def jinja_time_formatter(timestamp):
+    """ Reformats a datetime timedelta """
+    d = datetime.timedelta(seconds=int(timestamp.total_seconds()))
+    return str(d)
 
 
 @app.template_filter('to_nice_json')


### PR DESCRIPTION
This is just a proposal; let me know what you think.  This adds two
properties to `Task` objects:

- `offset_from_playbook` -- offset (as a `datetime.timedelta` object)
  of the task start time from the playbook start time.

- `offset_from_play` -- similar, but relative to the start of the play
  that contains this task.

This modifies the web UI to display tasks with the offset, rather than
absolute start/end times (which are still displayed for the play and
playbook).