### PR TITLE
Changes:

### DIFF
--- a/ara/filters.py
+++ b/ara/filters.py
@@ -10,13 +10,19 @@ def configure_template_filters(app):
     @app.template_filter('datefmt')
     def jinja_date_formatter(timestamp, format='%Y-%m-%d %H:%M:%S'):
         """ Reformats a datetime timestamp from str(datetime.datetime)"""
-        return datetime.datetime.strftime(timestamp, format)
+        if timestamp is None:
+            return 'n/a'
+        else:
+            return datetime.datetime.strftime(timestamp, format)
 
     @app.template_filter('timefmt')
     def jinja_time_formatter(timestamp):
         """ Reformats a datetime timedelta """
-        d = datetime.timedelta(seconds=int(timestamp.total_seconds()))
-        return str(d)
+        if timestamp is None:
+            return 'n/a'
+        else:
+            d = datetime.timedelta(seconds=int(timestamp.total_seconds()))
+            return str(d)
 
     @app.template_filter('to_nice_json')
     def jinja_to_nice_json(result):

--- a/ara/models.py
+++ b/ara/models.py
@@ -13,7 +13,7 @@
 #   under the License.
 
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 # This makes all the exceptions available as "models.<exception_name>".
 from flask_sqlalchemy import SQLAlchemy
@@ -38,7 +38,10 @@ class TimedEntity(object):
         '''Calculate `(time_end-time_start)` and return the resulting
         `datetime.timedelta` object.'''
 
-        return self.time_end - self.time_start
+        if self.time_end is None or self.time_start is None:
+            return timedelta(seconds=0)
+        else:
+            return self.time_end - self.time_start
 
     def start(self):
         '''Explicitly set `self.time_start`.'''

--- a/ara/models.py
+++ b/ara/models.py
@@ -254,11 +254,11 @@ class Stats(db.Model):
     playbook_id = db.Column(db.String(36), db.ForeignKey('playbooks.id'))
     host_id = db.Column(db.String(36), db.ForeignKey('hosts.id'))
 
-    changed = db.Column(db.Integer)
-    failed = db.Column(db.Integer)
-    ok = db.Column(db.Integer)
-    skipped = db.Column(db.Integer)
-    unreachable = db.Column(db.Integer)
+    changed = db.Column(db.Integer, default=0)
+    failed = db.Column(db.Integer, default=0)
+    ok = db.Column(db.Integer, default=0)
+    skipped = db.Column(db.Integer, default=0)
+    unreachable = db.Column(db.Integer, default=0)
 
     def __repr__(self):
         return '<Stats for %s>' % self.host.name

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Ensure the script will exit with an error if a test fails
+set -e
+
 # Runs ARA tests
 tox -e pep8
 tox -e py27

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -1,0 +1,149 @@
+from flask.ext.testing import TestCase
+from collections import defaultdict
+import random
+import pytest
+
+import ara.webapp as w
+import ara.models as m
+import ara.utils as u
+from ara.models import db
+
+from mock import Mock
+
+
+class TestApp(TestCase):
+    SQLALCHEMY_DATABASE_URI = 'sqlite://'
+    TESTING = True
+
+    def create_app(self):
+        return w.create_app(self)
+
+    def setUp(self):
+        m.db.create_all()
+
+        self.client = self.app.test_client()
+
+    def tearDown(self):
+        m.db.session.remove()
+        m.db.drop_all()
+
+    def ansible_run(self, complete=True):
+        playbook = m.Playbook(path='testing.yml')
+        play = m.Play(playbook=playbook, name='test play')
+        task = m.Task(play=play, playbook=playbook,
+                      action='test-action')
+        host = m.Host(name='localhost')
+        result = m.TaskResult(task=task, status='ok', host=host,
+                              result='this is a test')
+
+        self.ctx = dict(
+            playbook=playbook,
+            play=play,
+            task=task,
+            host=host,
+            result=result)
+
+        for obj in self.ctx.values():
+            if hasattr(obj, 'start'):
+                obj.start()
+            db.session.add(obj)
+
+        if complete:
+            stats = m.Stats(playbook=playbook, host=host)
+            self.ctx['stats'] = stats
+            db.session.add(stats)
+
+            for obj in self.ctx.values():
+                if hasattr(obj, 'stop'):
+                    obj.stop()
+
+        db.session.commit()
+
+    def test_overview(self):
+        res = self.client.get('/')
+        self.assertEqual(res.status_code, 200)
+
+    def test_list_host(self):
+        self.ansible_run()
+        res = self.client.get('/host/')
+        self.assertEqual(res.status_code, 200)
+
+    def test_list_playbook(self):
+        self.ansible_run()
+        res = self.client.get('/playbook/')
+        self.assertEqual(res.status_code, 200)
+
+    def test_list_playbook_incomplete(self):
+        self.ansible_run(complete=False)
+        res = self.client.get('/playbook/')
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.complete
+    def test_show_playbook(self):
+        self.ansible_run()
+        res = self.client.get('/playbook/{}'.format(
+            self.ctx['playbook'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.incomplete
+    def test_show_playbook_incomplete(self):
+        self.ansible_run(complete=False)
+        res = self.client.get('/playbook/{}'.format(
+            self.ctx['playbook'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.complete
+    def test_show_play(self):
+        self.ansible_run()
+        res = self.client.get('/play/{}'.format(
+            self.ctx['play'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.incomplete
+    def test_show_play_incomplete(self):
+        self.ansible_run(complete=False)
+        res = self.client.get('/play/{}'.format(
+            self.ctx['play'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.complete
+    def test_show_task(self):
+        self.ansible_run()
+        res = self.client.get('/task/{}'.format(
+            self.ctx['task'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.incomplete
+    def test_show_task_incomplete(self):
+        self.ansible_run(complete=False)
+        res = self.client.get('/task/{}'.format(
+            self.ctx['task'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.complete
+    def test_show_host(self):
+        self.ansible_run()
+        res = self.client.get('/host/{}'.format(
+            self.ctx['host'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.incomplete
+    def test_show_host_incomplete(self):
+        self.ansible_run(complete=False)
+        res = self.client.get('/host/{}'.format(
+            self.ctx['host'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.complete
+    def test_show_result(self):
+        self.ansible_run()
+        res = self.client.get('/result/{}'.format(
+            self.ctx['result'].id))
+        self.assertEqual(res.status_code, 200)
+
+    @pytest.mark.incomplete
+    def test_show_result_incomplete(self):
+        self.ansible_run(complete=False)
+        res = self.client.get('/result/{}'.format(
+            self.ctx['result'].id))
+        self.assertEqual(res.status_code, 200)


### PR DESCRIPTION
3524a38 (Lars Kellogg-Stedman, 4 minutes ago)
   ensure tests exit on failure

   the run_tests.sh script was masking failures because it would not exist
   when a test failed.

f480eaf (Lars Kellogg-Stedman, 10 minutes ago)
   fix handling of date/timestamps for incomplete runs

   we were assuming non-null values for timestamps in several places. These
   changes introduce explicit checks for null values and return an empty
   string (for display) or a timedelta of 0 (for duration) when there is no
   valid time data available.

   Closes #57.

cd54e63 (Lars Kellogg-Stedman, 23 minutes ago)
   add initial unit tests for webapp

   this includes test that trigger the bug reported in #57