### PR TITLE
Pass the HOME env variable to tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,6 +19,8 @@ commands = flake8 ara
 [testenv:py27]
 commands =
     py.test tests/unit
+passenv =
+    HOME
 
 [testenv:integration]
 whitelist_externals = bash
@@ -36,6 +38,8 @@ setenv =
     ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/ara/callback
     ARA_DATABASE = sqlite:////{toxinidir}/tests/integration/ansible.sqlite
     PYTHONUNBUFFERED = 1
+passenv =
+    HOME
 
 [flake8]
 # E123, E125 skipped as they are invalid PEP-8.


### PR DESCRIPTION
Workaround for https://github.com/ansible/ansible/issues/16032