### PR TITLE
Consistently sort playbook lists in the same order

### DIFF
--- a/ara/views/playbook.py
+++ b/ara/views/playbook.py
@@ -6,7 +6,8 @@ playbook = Blueprint('playbook', __name__)
 
 @playbook.route('/')
 def playbook_summary():
-    playbooks = models.Playbook.query.order_by(models.Playbook.time_start)
+    playbooks = (models.Playbook.query
+                 .order_by(models.Playbook.time_start.desc()))
     stats = utils.get_summary_stats(playbooks, 'playbook_id')
 
     return render_template('playbook_summary.html',


### PR DESCRIPTION
With the most recent on top as we do with the navbar.

Related issue #76.