### PR TITLE
moar testing: missing tests, and enable code coverage

### DIFF
--- a/ara/errorhandlers.py
+++ b/ara/errorhandlers.py
@@ -5,4 +5,4 @@ def configure_errorhandlers(app):
 
     @app.errorhandler(404)
     def page_not_found(error):
-        return render_template('errors/404.html', error=error)
+        return render_template('errors/404.html', error=error), 404

--- a/ara/views/play.py
+++ b/ara/views/play.py
@@ -4,7 +4,7 @@ from ara import models
 play = Blueprint('play', __name__)
 
 
-@play.route('/play/<play>')
+@play.route('/<play>')
 def show_play(play):
     play = models.Play.query.get(play)
     if play is None:

--- a/ara/views/playbook.py
+++ b/ara/views/playbook.py
@@ -15,7 +15,7 @@ def playbook_summary():
                            stats=stats)
 
 
-@playbook.route('/<playbook>/')
+@playbook.route('/<playbook>')
 def show_playbook(playbook):
     playbook = models.Playbook.query.get(playbook)
     if playbook is None:
@@ -35,8 +35,8 @@ def show_playbook(playbook):
                            tasks=tasks)
 
 
-@playbook.route('/<playbook>/results/')
-@playbook.route('/<playbook>/results/<host>/')
+@playbook.route('/<playbook>/results')
+@playbook.route('/<playbook>/results/<host>')
 @playbook.route('/<playbook>/results/<host>/<status>')
 def playbook_results(playbook, host=None, status=None):
     playbook = models.Playbook.query.get(playbook)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
+coverage
 flake8
 Flask-Testing
 mock
 pytest
+pytest-cov
 sphinx!=1.2.0,!=1.3b1,<1.3,>=1.1.2
 sphinx-rtd-theme

--- a/tests/unit/common.py
+++ b/tests/unit/common.py
@@ -1,0 +1,57 @@
+import random
+
+import ara.models as m
+from ara.models import db
+
+
+def ansible_run(complete=True):
+    '''Simulate a simple Ansible run by creating the
+    expected database objects.  This roughly approximates the
+    following playbook:
+
+        - hosts: host-<int>
+          tasks:
+            - test-action:
+
+    Where `<int>` is a random integer generated each time this
+    function is called.
+
+    Set the `complete` parameter to `False` to simulate an
+    aborted Ansible run.
+    '''
+
+    playbook = m.Playbook(path='testing.yml')
+    play = m.Play(playbook=playbook, name='test play')
+    task = m.Task(play=play, playbook=playbook,
+                  action='test-action')
+    host = m.Host(name='host-%04d' % random.randint(0, 9999))
+    host.playbooks.append(playbook)
+    result = m.TaskResult(task=task, status='ok', host=host,
+                          result='this is a test')
+
+    ctx = dict(
+        playbook=playbook,
+        play=play,
+        task=task,
+        host=host,
+        result=result)
+
+    for obj in ctx.values():
+        if hasattr(obj, 'start'):
+            obj.start()
+        db.session.add(obj)
+
+    db.session.commit()
+
+    if complete:
+        stats = m.Stats(playbook=playbook, host=host)
+        ctx['stats'] = stats
+        db.session.add(stats)
+
+        for obj in ctx.values():
+            if hasattr(obj, 'stop'):
+                obj.stop()
+
+    db.session.commit()
+
+    return ctx

--- a/tests/unit/test_filters.py
+++ b/tests/unit/test_filters.py
@@ -3,6 +3,7 @@ import ara.webapp as w
 import ara.models as m
 import datetime
 
+
 class TestFilters(TestCase):
     '''Tests for our Jinja2 filters'''
 
@@ -48,12 +49,24 @@ class TestFilters(TestCase):
 
         self.assertEqual(res, datestr)
 
+    def test_datefmt_none(self):
+        t = self.env.from_string('{{ date | datefmt }}')
+        res = t.render(date=None)
+
+        self.assertEqual(res, 'n/a')
+
     def test_timefmt(self):
         time = datetime.timedelta(seconds=90061)
         t = self.env.from_string('{{ time | timefmt }}')
         res = t.render(time=time)
 
         self.assertEqual(res, '1 day, 1:01:01')
+
+    def test_timefmt_none(self):
+        t = self.env.from_string('{{ time | timefmt }}')
+        res = t.render(time=None)
+
+        self.assertEqual(res, 'n/a')
 
     def test_from_json(self):
         data = '{"key": "value"}'
@@ -70,6 +83,13 @@ class TestFilters(TestCase):
         self.assertEqual(res,
                          u'{\n    "key": "value"\n}')
 
+    def test_to_json_fails(self):
+        data = datetime.datetime.now()
+        t = self.env.from_string('{{ data | to_nice_json }}')
+        res = t.render(data=data)
+
+        self.assertEqual(res, str(data))
+
     def test_to_json_from_string(self):
         data = '{"key": "value"}'
         t = self.env.from_string('{{ data | to_nice_json | safe }}')
@@ -77,7 +97,6 @@ class TestFilters(TestCase):
 
         self.assertEqual(res,
                          u'{\n    "key": "value"\n}')
-
 
     def test_to_json_from_invalid_string(self):
         # json.dumps does not raise exception on a non-json string,

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,104 @@
+from flask.ext.testing import TestCase
+import ara.webapp as w
+import ara.models as m
+import ara.utils as u
+import json
+
+from mock import Mock
+
+
+class TestUtils(TestCase):
+    '''Tests the utils module'''
+
+    SQLALCHEMY_DATABASE_URI = 'sqlite://'
+    TESTING = True
+
+    def create_app(self):
+        return w.create_app(self)
+
+    def setUp(self):
+        m.db.create_all()
+        self.env = self.app.jinja_env
+
+    def tearDown(self):
+        m.db.session.remove()
+        m.db.drop_all()
+
+    def test_fields_from_iter(self):
+        fields = (
+            ('Field 1',),
+            ('Field 2', 'field2'),
+            ('Field 3', 'field3.value'),
+        )
+
+        items = [
+            Mock(field_1='value 1', field2='value 2',
+                 field3=Mock(value='value 3')),
+        ]
+
+        res = u.fields_from_iter(fields, items)
+
+        self.assertEqual(res,
+                         (('Field 1', 'Field 2', 'Field 3'),
+                          [['value 1', 'value 2', 'value 3']]))
+
+    def test_fields_from_iter_xform(self):
+        fields = (
+            ('Field 1',),
+            ('Field 2', 'field2'),
+        )
+
+        items = [
+            Mock(field_1='value 1', field2='value 2'),
+        ]
+
+        res = u.fields_from_iter(fields, items,
+                                 xforms={'Field 2': lambda x: x.upper()})
+
+        self.assertEqual(res,
+                         (('Field 1', 'Field 2'), [['value 1', 'VALUE 2']]))
+
+    def test_fields_from_object(self):
+        fields = (
+            ('Field 1',),
+            ('Field 2', 'field2'),
+        )
+
+        obj = Mock(field_1='value 1', field2='value 2')
+
+        res = u.fields_from_object(fields, obj)
+
+        self.assertEqual(res,
+                         (('Field 1', 'Field 2'), ['value 1', 'value 2']))
+
+    def test_fields_from_object_xform(self):
+        fields = (
+            ('Field 1',),
+            ('Field 2', 'field2'),
+        )
+
+        obj = Mock(field_1='value 1', field2='value 2')
+
+        res = u.fields_from_object(fields, obj,
+                                   xforms={'Field 2': lambda x: x.upper()})
+
+        self.assertEqual(res,
+                         (('Field 1', 'Field 2'), ['value 1', 'VALUE 2']))
+
+    def test_status_to_query(self):
+        res = u.status_to_query('ok')
+        self.assertEqual(res, {'status': 'ok'})
+
+    def test_status_to_query_changed(self):
+        res = u.status_to_query('changed')
+        self.assertEqual(res, {'status': 'ok', 'changed': True})
+
+    def test_format_json(self):
+        data = json.dumps({'name': 'value'})
+        res = u.format_json(json.dumps(data))
+        self.assertEqual(res,
+                         '"{\\"name\\": \\"value\\"}"')
+
+    def test_format_json_fail(self):
+        res = u.format_json('{invalid:}')
+        self.assertEqual(res, '{invalid:}')

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,12 @@ commands =
 passenv =
     HOME
 
+[testenv:cover]
+commands =
+    py.test --cov=ara --cov-report=html tests/unit
+passenv =
+    HOME
+
 [testenv:integration]
 whitelist_externals = bash
                       rm


### PR DESCRIPTION
this commit brings test coverage of our jinja2 filters to 100% and adds
some unit tests for the `utils` module.  It also adds code coverage testing
to the tox configuration.  This will produce coverage statistics on stdout
when running tox; you can also manually run
`py.test --cov=ara --cov-report=html test/unit` to get an HTML version of
the report in the `htmlcov` directory.

note that this pr depends on #81