### PR TITLE
better handling of aborted ansible runs and cli enhancements (take 2)

### DIFF
--- a/ara/cli/play.py
+++ b/ara/cli/play.py
@@ -32,10 +32,28 @@ class PlayList(Lister):
     """Returns a list of plays"""
     log = logging.getLogger(__name__)
 
-    def take_action(self, parsed_args):
+    def get_parser(self, prog_name):
+        parser = super(PlayList, self).get_parser(prog_name)
+        g = parser.add_mutually_exclusive_group(required=True)
+        g.add_argument(
+            '--playbook', '-b',
+            metavar='<playbook-id>',
+            help='Show plays from specified playbook',
+        )
+        g.add_argument(
+            '--all', '-a',
+            action='store_true',
+            help='Show all plays in database')
+        return parser
+
+    def take_action(self, args):
         plays = (models.Play.query
                  .join(models.Playbook)
                  .filter(models.Play.playbook_id == models.Playbook.id))
+
+        if args.playbook:
+            plays = (plays
+                     .filter(models.Play.playbook_id == args.playbook))
 
         return utils.fields_from_iter(
             FIELDS, plays,

--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -17,13 +17,16 @@ import logging
 
 from cliff.lister import Lister
 from cliff.show import ShowOne
+from cliff.command import Command
 from ara import models, utils
+from ara.models import db
 
 FIELDS = (
     ('ID',),
     ('Path',),
     ('Time Start',),
     ('Time End',),
+    ('Complete',),
 )
 
 
@@ -31,8 +34,27 @@ class PlaybookList(Lister):
     """Returns a list of playbooks"""
     log = logging.getLogger(__name__)
 
-    def take_action(self, parsed_args):
-        playbooks = models.Playbook.query.all()
+    def get_parser(self, prog_name):
+        parser = super(PlaybookList, self).get_parser(prog_name)
+        parser.add_argument(
+            '--incomplete', '-I',
+            action='store_true',
+            help='Only show incomplete playbook runs',
+        )
+        parser.add_argument(
+            '--complete', '-C',
+            action='store_true',
+            help='Only show incomplete playbook runs',
+        )
+        return parser
+
+    def take_action(self, args):
+        playbooks = models.Playbook.query
+        if args.incomplete:
+            playbooks = playbooks.filter_by(complete=False)
+        if args.complete:
+            playbooks = playbooks.filter_by(complete=True)
+
         return utils.fields_from_iter(FIELDS, playbooks)
 
 
@@ -49,6 +71,73 @@ class PlaybookShow(ShowOne):
         )
         return parser
 
-    def take_action(self, parsed_args):
-        playbook = models.Playbook.query.get(parsed_args.playbook_id)
+    def take_action(self, args):
+        playbook = models.Playbook.query.get(args.playbook_id)
         return utils.fields_from_object(FIELDS, playbook)
+
+
+class PlaybookDelete(Command):
+    """Delete playbooks from the database."""
+    log = logging.getLogger(__name__)
+
+    def get_parser(self, prog_name):
+        parser = super(PlaybookDelete, self).get_parser(prog_name)
+        parser.add_argument(
+            '--ignore-errors', '-i',
+            action='store_true',
+            help='Do not exit if a playbook cannot be found')
+        parser.add_argument(
+            '--incomplete', '-I',
+            action='store_true',
+            help='Delete all incomplete playbook runs',
+        )
+        parser.add_argument(
+            'playbook_id',
+            nargs='*',
+            metavar='<playbook-id>',
+            help='Playbook(s) to delete',
+        )
+        return parser
+
+    def take_action(self, args):
+        if not args.playbook_id and not args.incomplete:
+            raise RuntimeError('Nothing to delete')
+
+        if args.playbook_id and args.incomplete:
+            raise RuntimeError('You may not use --incomplete with '
+                               'a list of playbooks')
+
+        if args.incomplete:
+            pids = (playbook.id for playbook in
+                    models.Playbook.query.filter_by(complete=False))
+        else:
+            pids = []
+            for pid in args.playbook_id:
+                try:
+                    res = models.Playbook.query.get(pid)
+                    if res is None:
+                        raise ValueError('playbook does not exist')
+                except Exception as err:
+                    if args.ignore_errors:
+                        self.log.warning('unable to delete playbook %s '
+                                         '(skipping): %s', pid, err)
+                    else:
+                        raise RuntimeError('unable to delete playbook '
+                                           'id %s: %s' % (pid, err))
+                else:
+                    pids.append(pid)
+
+        for pid in pids:
+            self.log.warning('deleting playbook %s', pid)
+            playbook = models.Playbook.query.get(pid)
+            db.session.delete(playbook)
+            orphan_hosts = (models.Host.query
+                            .outerjoin(models.HostPlaybook)
+                            .filter(models.HostPlaybook.host_id == None))  # NOQA
+
+            for host in orphan_hosts:
+                self.log.warning('deleting host %s (no more playbooks)',
+                                 host.name)
+                db.session.delete(host)
+
+        db.session.commit()

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ console_scripts =
 ara.cli =
     playbook list = ara.cli.playbook:PlaybookList
     playbook show = ara.cli.playbook:PlaybookShow
+    playbook delete = ara.cli.playbook:PlaybookDelete
     task list = ara.cli.task:TaskList
     task show = ara.cli.task:TaskShow
     play list = ara.cli.play:PlayList

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ sitepackages=True
 usedevelop = True
 install_command = pip install -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
-deps = -r{toxinidir}/test-requirements.txt
+deps = -r{toxinidir}/requirements.txt
+	-r{toxinidir}/test-requirements.txt
 
 [testenv:docs]
 commands = python setup.py build_sphinx
@@ -36,11 +37,11 @@ commands =
     rm -rf "{toxinidir}/tests/integration/build"
     ansible-playbook -vv {toxinidir}/tests/integration/playbook.yml
     bash -c "ara host show $(ara host list -c ID -f value |head -n1)"
-    bash -c "ara play show $(ara play list -c ID -f value |head -n1)"
+    bash -c "ara play show $(ara play list -a -c ID -f value |head -n1)"
     bash -c "ara playbook show $(ara playbook list -c ID -f value |head -n1)"
-    bash -c "ara result show $(ara result list -c ID -f value |head -n1) --long"
+    bash -c "ara result show $(ara result list -a -c ID -f value |head -n1) --long"
     bash -c "ara stats show $(ara stats list -c ID -f value |head -n1)"
-    bash -c "ara task show $(ara task list -c ID -f value |head -n1)"
+    bash -c "ara task show $(ara task list -a -c ID -f value |head -n1)"
     bash -c "ara generate --path {toxinidir}/tests/integration/build && tree {toxinidir}/tests/integration/build"
 setenv =
     ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/ara/callback


### PR DESCRIPTION
this commit contains two major changes:

1. we introduce a new "complete" column to the database that clearly
  marks playbook entries that belong to aborted ansible runs.

  - we introduce command line changes to deleting with these playbooks:

    - `ara playbook list` learned about the `--complete` and
     `--incomplete` flags.

    - `ara playbook` learned how to `delete` playbooks; `ara playbook
     delete --incomplete` will delete all incomplete playbooks.

2. command line changes that make most of the `list` commands not dump
  everything in the database by default.  Most of the list commands
  learned about a `--all` (`-a`) flag for dumping all objects, and
  then variously `--playbook <playbook_id>` for dumping objects owned
  by a playbook, `--play <play_id>` for dumping objects owned by a
  play, `--task <task_id>`, and `--host <host_name>`.