### PR TITLE
stop catching bare Exceptions

### DIFF
--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -113,17 +113,13 @@ class PlaybookDelete(Command):
         else:
             pids = []
             for pid in args.playbook_id:
-                try:
-                    res = models.Playbook.query.get(pid)
-                    if res is None:
-                        raise ValueError('playbook does not exist')
-                except Exception as err:
+                res = models.Playbook.query.get(pid)
+                if res is None:
                     if args.ignore_errors:
-                        self.log.warning('unable to delete playbook %s '
-                                         '(skipping): %s', pid, err)
+                        self.log.warning('Playbook %s does not exist '
+                                         '(ignoring)' % pid)
                     else:
-                        raise RuntimeError('unable to delete playbook '
-                                           'id %s: %s' % (pid, err))
+                        raise RuntimeError('Playbook %s does not exist' % pid)
                 else:
                     pids.append(pid)
 

--- a/ara/filters.py
+++ b/ara/filters.py
@@ -32,7 +32,7 @@ def configure_template_filters(app):
         except (ValueError, TypeError):
             try:
                 return json.dumps(result, indent=4, sort_keys=True)
-            except Exception as err:
+            except TypeError as err:
                 log.error('failed to dump json: %s', err)
                 return result
 
@@ -40,7 +40,7 @@ def configure_template_filters(app):
     def jinja_from_json(val):
         try:
             return json.loads(val)
-        except Exception as err:
+        except ValueError as err:
             log.error('failed to load json: %s', err)
             return val
 

--- a/ara/utils.py
+++ b/ara/utils.py
@@ -148,5 +148,5 @@ def format_json(val):
                           indent=4,
                           sort_keys=True,
                           default=str)
-    except Exception:
+    except (TypeError, ValueError):
         return val


### PR DESCRIPTION
catching a bare `Exception` can mask errors elsewhere in the code and
generally make problems hard to diagnose.  These removes all instances
where our code had:

    except Exception: