### PR TITLE
Require decorator>=4.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask-SQLAlchemy
 Flask-Script
 Frozen-Flask
 pbr>=1.6
-decorator
+decorator>=4.0.1
 cliff
 setuptools>=11.3
 ansible!=2.0.2.0,>=2.0.1.0


### PR DESCRIPTION
This is required due to our usage of the decorate function which
landed in 4.0.1.
Any other previous versions do not have it as per browsing the
source at https://pypi.python.org/simple/decorator/ .