### PR TITLE
Re-work integration tests out of tox, add ansible integration tests

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,30 +2,45 @@ Installing ARA
 ==============
 Installing ARA is easy.
 
-Packaged dependencies
----------------------
-RHEL, CentOS, Fedora
-~~~~~~~~~~~~~~~~~~~~
+RHEL, CentOS, Fedora packages
+-----------------------------
+Required dependencies
+~~~~~~~~~~~~~~~~~~~~~
 ::
 
     yum -y install gcc python-devel libffi-devel openssl-devel
 
-Ubuntu, Debian
-~~~~~~~~~~~~~~
+Development or integration testing dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+    yum -y install python-virtualenv git hg svn rubygems python-setuptools tree
+    easy_install pip
+
+Ubuntu, Debian packages
+-----------------------
+Required dependencies
+~~~~~~~~~~~~~~~~~~~~~
 ::
 
     apt-get -y install gcc python-dev libffi-dev libssl-dev
 
-From source
------------
+Development or integration testing dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+::
+
+    apt-get -y install python-pip python-virtualenv ruby git mercurial subversion tree
+
+Installing ARA from source
+--------------------------
 ::
 
     git clone https://github.com/dmsimard/ara
     cd ara
     pip install .
 
-From pip
---------
+Installing ARA from pip
+-----------------------
 ::
 
     pip install ara

--- a/other-requirements.txt
+++ b/other-requirements.txt
@@ -1,8 +1,16 @@
-gcc [platform:rpm]
+gcc
+python-virtualenv
+git
+tree
+hg [platform:rpm]
 libffi-devel [platform:rpm]
 openssl-devel [platform:rpm]
 python-devel [platform:rpm]
-gcc [platform:dpkg]
+rubygems [platform:rpm]
+svn [platform:rpm]
 libffi-dev [platform:dpkg]
 libssl-dev [platform:dpkg]
 python-dev [platform:dpkg]
+subversion [platform:dpkg]
+mercurial [platform:dpkg]
+ruby [platform:dpkg]

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -4,7 +4,10 @@
 set -e
 
 # Runs ARA tests
+tox -e docs
 tox -e pep8
 tox -e py27
-tox -e integration
-tox -e docs
+tox -e ara-integration
+# ansible-integration tests can be run manually for the time being
+# It requires jumping through hoops if we want to run them inside Travis CI
+# tox -e ansible-integration

--- a/tests/integration/ansible.sh
+++ b/tests/integration/ansible.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# This script runs ansible-specific integration tests with ARA configured.
+# It can be run by itself but is expected to be run from tox -e integration.
+function integration_warning {
+    echo "###################### !!!!!!! WARNING !!!!!!! ######################"
+    echo "This script will run Ansible destructive integration tests."
+    echo "- https://github.com/ansible/ansible/tree/devel/test/integration"
+    echo "It will write files, install packages and modify configuration."
+    echo "You should really only run this on virtual or ephemeral environments."
+    echo "###################### !!!!!!! WARNING !!!!!!! ######################"
+    read -p "Are you sure you want to proceed ? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Aborting execution"
+        exit 1
+    fi
+}
+
+DESTRUCTIVE_TESTS=${DESTRUCTIVE_TESTS:-"false"}
+[[ "${DESTRUCTIVE_TESTS}" == "false" ]] && integration_warning
+
+set -ex
+# Setup ARA
+export ANSIBLE_CALLBACK_PLUGINS=${ANSIBLE_CALLBACK_PLUGINS:-/usr/lib/python2.7/site-packages/ara/callback:$VIRTUAL_ENV/lib/python2.7/site-packages/ara/callback:/usr/local/lib/python2.7/dist-packages/ara/callback}
+
+# All integration test data should be kept in ara/tests/integration/
+SCRIPT_CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_DIR="${SCRIPT_CWD}/build"
+DATABASE="${SCRIPT_CWD}/ansible.sqlite"
+export ARA_DATABASE="sqlite:///${DATABASE}"
+
+# Cleanup previous run
+rm -rf $DATABASE
+rm -rf $BUILD_DIR
+rm -rf ansible
+
+# Setup and run Ansible destructive integration tests
+# Note: Assumes pip and the packages in other-requirements.txt have been installed
+TAG=${1:-v2.0.1.0-1}
+git clone https://github.com/ansible/ansible
+pushd ansible
+git checkout ${TAG}
+cd test/integration
+make destructive
+popd
+
+# Run test commands
+ara host show $(ara host list -c ID -f value |head -n1)
+ara host facts $(ara host list -c ID -f value |head -n1)
+ara play show $(ara play list -a -c ID -f value |head -n1)
+ara playbook show $(ara playbook list -c ID -f value |head -n1)
+ara result show $(ara result list -a -c ID -f value |tail -n1) --long
+ara stats show $(ara stats list -c ID -f value |head -n1)
+ara task show $(ara task list -a -c ID -f value |head -n1)
+ara generate ${BUILD_DIR} && tree ${BUILD_DIR}

--- a/tests/integration/ara.sh
+++ b/tests/integration/ara.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -ex
+# This script runs ara-specific integration tests.
+# It can be run by itself but is expected to be run from tox -e integration
+
+# Setup ARA
+export ANSIBLE_CALLBACK_PLUGINS=${ANSIBLE_CALLBACK_PLUGINS:-/usr/lib/python2.7/site-packages/ara/callback:$VIRTUAL_ENV/lib/python2.7/site-packages/ara/callback:/usr/local/lib/python2.7/dist-packages/ara/callback}
+
+# All integration test data should be kept in ara/tests/integration/
+SCRIPT_CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BUILD_DIR="${SCRIPT_CWD}/build"
+DATABASE="${SCRIPT_CWD}/ansible.sqlite"
+export ARA_DATABASE="sqlite:///${DATABASE}"
+
+# Cleanup previous run
+rm -rf $DATABASE
+rm -rf $BUILD_DIR
+
+# Run test playbook
+ansible-playbook -vv ${SCRIPT_CWD}/playbook.yml
+
+# Run test commands
+ara host show $(ara host list -c ID -f value |head -n1)
+ara host facts $(ara host list -c ID -f value |head -n1)
+ara play show $(ara play list -a -c ID -f value |head -n1)
+ara playbook show $(ara playbook list -c ID -f value |head -n1)
+ara result show $(ara result list -a -c ID -f value |tail -n1) --long
+ara stats show $(ara stats list -c ID -f value |head -n1)
+ara task show $(ara task list -a -c ID -f value |head -n1)
+ara generate ${BUILD_DIR} && tree ${BUILD_DIR}

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ usedevelop = True
 install_command = pip install -U {opts} {packages}
 setenv = VIRTUAL_ENV={envdir}
 deps = -r{toxinidir}/requirements.txt
-	-r{toxinidir}/test-requirements.txt
+       -r{toxinidir}/test-requirements.txt
 
 [testenv:docs]
 commands = python setup.py build_sphinx
@@ -29,24 +29,22 @@ commands =
 passenv =
     HOME
 
-[testenv:integration]
+[testenv:ara-integration]
 whitelist_externals = bash
-                      rm
 commands =
-    rm -f "{toxinidir}/tests/integration/ansible.sqlite"
-    rm -rf "{toxinidir}/tests/integration/build"
-    ansible-playbook -vv {toxinidir}/tests/integration/playbook.yml
-    bash -c "ara host show $(ara host list -c ID -f value |head -n1)"
-    bash -c "ara host facts $(ara host list -c ID -f value |head -n1)"
-    bash -c "ara play show $(ara play list -a -c ID -f value |head -n1)"
-    bash -c "ara playbook show $(ara playbook list -c ID -f value |head -n1)"
-    bash -c "ara result show $(ara result list -a -c ID -f value |tail -n1) --long"
-    bash -c "ara stats show $(ara stats list -c ID -f value |head -n1)"
-    bash -c "ara task show $(ara task list -a -c ID -f value |head -n1)"
-    bash -c "ara generate {toxinidir}/tests/integration/build && tree {toxinidir}/tests/integration/build"
+    bash -c "{toxinidir}/tests/integration/ara.sh"
 setenv =
     ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/ara/callback
-    ARA_DATABASE = sqlite:////{toxinidir}/tests/integration/ansible.sqlite
+    PYTHONUNBUFFERED = 1
+passenv =
+    HOME
+
+[testenv:ansible-integration]
+whitelist_externals = bash
+commands =
+    bash -c "{toxinidir}/tests/integration/ansible.sh"
+setenv =
+    ANSIBLE_CALLBACK_PLUGINS = {toxinidir}/ara/callback
     PYTHONUNBUFFERED = 1
 passenv =
     HOME


### PR DESCRIPTION
This commit splits bash stuff outside of tox because it makes more
sense that way.
We also start testing Ansible destructive integration tests.