### PR TITLE
cli code and formatting cleanup

### DIFF
--- a/ara/cli/host.py
+++ b/ara/cli/host.py
@@ -19,11 +19,13 @@ import six
 
 from cliff.lister import Lister
 from cliff.show import ShowOne
-from ara import models, utils
+from ara import models
+from ara.fields import Field
 
 FIELDS = (
-    ('ID',),
-    ('Name',),
+    Field('ID'),
+    Field('Name'),
+    Field('Latest facts', 'facts.timestamp')
 )
 
 
@@ -50,7 +52,9 @@ class HostList(Lister):
                      .join(models.Playbook)
                      .filter(models.Playbook.id == args.playbook))
 
-        return utils.fields_from_iter(FIELDS, hosts)
+        return [[field.name for field in FIELDS],
+                [[field(host) for field in FIELDS]
+                 for host in hosts]]
 
 
 class HostShow(ShowOne):
@@ -74,7 +78,8 @@ class HostShow(ShowOne):
         except models.NoResultFound:
             raise RuntimeError('Host %s could not be found' % args.host)
 
-        return utils.fields_from_object(FIELDS, host)
+        return [[field.name for field in FIELDS],
+                [field(host) for field in FIELDS]]
 
 
 class HostFacts(ShowOne):

--- a/ara/cli/play.py
+++ b/ara/cli/play.py
@@ -17,14 +17,25 @@ import logging
 
 from cliff.lister import Lister
 from cliff.show import ShowOne
-from ara import models, utils
+from ara import models
+from ara.fields import Field
 
-FIELDS = (
-    ('ID',),
-    ('Name',),
-    ('Playbook',),
-    ('Time Start',),
-    ('Time End',),
+LIST_FIELDS = (
+    Field('ID'),
+    Field('Name'),
+    Field('Playbook', 'playbook.path'),
+    Field('Time Start'),
+    Field('Duration'),
+)
+
+SHOW_FIELDS = (
+    Field('ID'),
+    Field('Name'),
+    Field('Playbook ID', 'playbook.id'),
+    Field('Playbook Path', 'playbook.path'),
+    Field('Time Start'),
+    Field('Time End'),
+    Field('Duration'),
 )
 
 
@@ -56,11 +67,9 @@ class PlayList(Lister):
             plays = (plays
                      .filter(models.Play.playbook_id == args.playbook))
 
-        return utils.fields_from_iter(
-            FIELDS, plays,
-            xforms={
-                'Playbook': lambda p: p.path,
-            })
+        return [[field.name for field in LIST_FIELDS],
+                [[field(play) for field in LIST_FIELDS]
+                 for play in plays]]
 
 
 class PlayShow(ShowOne):
@@ -82,8 +91,5 @@ class PlayShow(ShowOne):
             raise RuntimeError('Play %s could not be found' %
                                args.play_id)
 
-        return utils.fields_from_object(
-            FIELDS, play,
-            xforms={
-                'Playbook': (lambda p: '{0} ({1})'.format(p.path, p.id)),
-            })
+        return [[field.name for field in SHOW_FIELDS],
+                [field(play) for field in SHOW_FIELDS]]

--- a/ara/cli/playbook.py
+++ b/ara/cli/playbook.py
@@ -18,15 +18,25 @@ import logging
 from cliff.lister import Lister
 from cliff.show import ShowOne
 from cliff.command import Command
-from ara import models, utils
+from ara import models
 from ara.models import db
+from ara.fields import Field
 
-FIELDS = (
-    ('ID',),
-    ('Path',),
-    ('Time Start',),
-    ('Time End',),
-    ('Complete',),
+LIST_FIELDS = (
+    Field('ID'),
+    Field('Path'),
+    Field('Time Start'),
+    Field('Duration'),
+    Field('Complete'),
+)
+
+SHOW_FIELDS = (
+    Field('ID'),
+    Field('Path'),
+    Field('Time Start'),
+    Field('Time End'),
+    Field('Duration'),
+    Field('Complete'),
 )
 
 
@@ -57,7 +67,9 @@ class PlaybookList(Lister):
         if args.complete:
             playbooks = playbooks.filter_by(complete=True)
 
-        return utils.fields_from_iter(FIELDS, playbooks)
+        return [[field.name for field in LIST_FIELDS],
+                [[field(playbook) for field in LIST_FIELDS]
+                 for playbook in playbooks]]
 
 
 class PlaybookShow(ShowOne):
@@ -78,8 +90,8 @@ class PlaybookShow(ShowOne):
         if playbook is None:
             raise RuntimeError('Playbook %s could not be found' %
                                args.playbook_id)
-
-        return utils.fields_from_object(FIELDS, playbook)
+        return [[field.name for field in SHOW_FIELDS],
+                [field(playbook) for field in SHOW_FIELDS]]
 
 
 class PlaybookDelete(Command):

--- a/ara/cli/result.py
+++ b/ara/cli/result.py
@@ -17,16 +17,43 @@ import logging
 
 from cliff.lister import Lister
 from cliff.show import ShowOne
-from ara import models, utils
+from ara import models
+from ara.fields import Field
 
-FIELDS = (
-    ('ID',),
-    ('Host', 'host.name'),
-    ('Task',),
-    ('Status', 'derived_status'),
-    ('Ignore Errors',),
-    ('Time Start',),
-    ('Time End',),
+LIST_FIELDS = (
+    Field('ID'),
+    Field('Host', 'host.name'),
+    Field('Action', 'task.action'),
+    Field('Status', 'derived_status'),
+    Field('Ignore Errors'),
+    Field('Time Start'),
+    Field('Duration'),
+)
+
+SHOW_FIELDS = (
+    Field('ID'),
+    Field('Playbook ID', 'task.playbook.id'),
+    Field('Playbook Path', 'task.playbook.path'),
+    Field('Play ID', 'task.play.id'),
+    Field('Play Name', 'task.play.name'),
+    Field('Task ID', 'task.id'),
+    Field('Task Name', 'task.name'),
+    Field('Host', 'host.name'),
+    Field('Action', 'task.action'),
+    Field('Status', 'derived_status'),
+    Field('Ignore Errors'),
+    Field('Time Start'),
+    Field('Time End'),
+    Field('Duration'),
+)
+
+SHOW_FIELDS_LONG = SHOW_FIELDS + (
+    Field('Result', 'result|from_json',
+          template='{{value|to_nice_json|safe}}'),
+)
+
+SHOW_FIELDS_RAW = SHOW_FIELDS + (
+    Field('Result', 'result|from_json'),
 )
 
 
@@ -41,19 +68,19 @@ class ResultList(Lister):
         g.add_argument(
             '--playbook', '-b',
             metavar='<playbook-id>',
-            help='Playbook from which to list results',)
+            help='Playbook from which to list results')
         g.add_argument(
             '--play', '-p',
             metavar='<play-id>',
-            help='Play from which to list results',)
+            help='Play from which to list results')
         g.add_argument(
             '--task', '-t',
             metavar='<task-id>',
-            help='Task from which to list results',)
+            help='Task from which to list results')
         g.add_argument(
             '--all', '-a',
             action='store_true',
-            help='List all results in the database',)
+            help='List all results in the database')
         return parser
 
     def take_action(self, args):
@@ -74,11 +101,9 @@ class ResultList(Lister):
             results = (results
                        .filter(models.TaskResult.task_id == args.task))
 
-        return utils.fields_from_iter(
-            FIELDS, results,
-            xforms={
-                'Task': lambda t: t.name,
-            })
+        return [[field.name for field in LIST_FIELDS],
+                [[field(result) for field in LIST_FIELDS]
+                 for result in results]]
 
 
 class ResultShow(ShowOne):
@@ -89,8 +114,17 @@ class ResultShow(ShowOne):
         parser = super(ResultShow, self).get_parser(prog_name)
         parser.add_argument(
             '--long', '-l',
-            action='store_true',
-            help='Show full JSON result',
+            dest='format',
+            action='store_const',
+            const='long',
+            help='Show full result',
+        )
+        parser.add_argument(
+            '--raw', '-r',
+            dest='format',
+            action='store_const',
+            const='raw',
+            help='Show full result',
         )
         parser.add_argument(
             'result_id',
@@ -100,18 +134,17 @@ class ResultShow(ShowOne):
         return parser
 
     def take_action(self, args):
-        _fields = list(FIELDS)
-        if args.long:
-            _fields.append(('Result',))
-
         result = models.TaskResult.query.get(args.result_id)
         if result is None:
             raise RuntimeError('Result %s could not be found' %
                                args.result_id)
 
-        return utils.fields_from_object(
-            _fields, result,
-            xforms={
-                'Task': lambda t: '{0} ({1})'.format(t.name, t.id),
-                'Result': lambda r: utils.format_json(r),
-            })
+        if args.format == 'long':
+            fields = SHOW_FIELDS_LONG
+        elif args.format == 'raw':
+            fields = SHOW_FIELDS_RAW
+        else:
+            fields = SHOW_FIELDS
+
+        return [[field.name for field in fields],
+                [field(result) for field in fields]]

--- a/ara/fields.py
+++ b/ara/fields.py
@@ -1,0 +1,65 @@
+import datetime
+from flask import render_template_string
+from jinja2 import Undefined
+
+from ara import app
+
+implicit_templates = {
+    datetime.datetime: '{{ value|datefmt }}',
+    datetime.timedelta: '{{ value|timefmt }}',
+}
+
+
+class Field(object):
+    '''A utility class for extracting a value from an object hierarchy and
+    formatting it using a Jinja2 template.'''
+
+    def __init__(self, name, path=None, template=None,
+                 raise_on_err=False):
+        '''Initialize a Field object.
+
+        - `name` -- field label (used for display)
+        - `path` -- a Jinja2 expression used to extract a value from
+           an object hierarchy.  If not specified, this is derived from
+           `name` by setting `name` to lower case and replacing ` ` with
+           `_`.
+        - `template` -- a Jinja2 template that will be used to render
+          the value for display.
+        - `raise_on_err` -- raise an AttributeError if the specified
+          `path` does not return a value.
+        '''
+
+        if path is None:
+            path = name.lower().replace(' ', '_')
+
+        self.name = name
+        self.template = template
+        self.raise_on_err = raise_on_err
+        self.path = path
+
+        self.expr = app.jinja_env.compile_expression(
+            path, undefined_to_none=False)
+
+    def __call__(self, obj):
+        '''Extract a value from `obj` and return the formatted value.'''
+
+        # Extract value from the object.
+        value = self.expr(**{x: getattr(obj, x)
+                             for x in dir(obj)
+                             if not x.startswith('_')})
+
+        if value is Undefined:
+            if self.raise_on_err:
+                raise AttributeError(self.path)
+
+        # Get a template, maybe
+        template = (self.template if self.template
+                    else implicit_templates.get(type(value)))
+
+        if template:
+            return render_template_string(template, value=value)
+        else:
+            return value
+
+    def __str__(self):
+        return self.name

--- a/ara/utils.py
+++ b/ara/utils.py
@@ -17,51 +17,6 @@ from collections import defaultdict
 from ara import models
 
 
-def fields_from_iter(fields, items, xforms=None):
-    '''Returns column headers and data for use by
-    `cliff.lister.Lister`.  In this function and in
-    `fields_from_object`, fields are specified as a list of
-    `(column_name, object_path)` tuples.  The `object_path` can be
-    omitted if it can be inferred from the column name by converting
-    the name to lowercase and converting ' ' to '_'.  For example:
-
-        fields = (
-            ('ID',),
-            ('Name',),
-            ('Playbook',),
-        )
-
-    The `xforms` parameter is a dictionary maps column names to
-    callables that will be used to format the corresponding value.
-    For example:
-
-        xforms = {
-            'Playbook': lambda p: p.name,
-        }
-    '''
-
-    xforms = xforms or {}
-
-    return (zip(*fields)[0], [
-        [xform(v) for v, xform in
-         [(get_field_attr(item, f[0]), f[1]) for f in
-          [(field, xforms.get(field[0], lambda x: x)) for field in fields]]]
-        for item in items])
-
-
-def fields_from_object(fields, obj, xforms=None):
-    '''Returns labels and values for use by `cliff.show.ShowOne`.  See
-    the documentation for `fields_from_iter` for details.'''
-
-    xforms = xforms or {}
-
-    return (zip(*fields)[0],
-            [xform(v) for v, xform in
-             [(get_field_attr(obj, f[0]), f[1]) for f in
-              [(field, xforms.get(field[0], lambda x: x))
-               for field in fields]]])
-
-
 def status_to_query(status):
     """
     Returns a dict to be used as filter kwargs based on status
@@ -119,27 +74,6 @@ def get_summary_stats(items, attr):
             'unreachable': sum([int(stat.unreachable) for stat in stats])
         }
     return data
-
-
-def get_field_attr(obj, field):
-    '''Returns the value of an attribute path applied to an object.
-    The attribute path is either made available explicitly as
-    `field[1]` or implicitly by converting `field[0]` to lower case
-    and converting ' ' to '_'.  In other words, given:
-
-        field = ('Name',)
-
-    `get_field_attribute(obj, field)` would return the value of the
-    `name` attribute of `obj`.  On other hand, given:
-
-        field = ('Name', 'playbook.name')
-
-    `get_field_attribute(obj, field)` would return the value of the
-    `name` attribute of the `playbook` attribute of `obj`.
-    '''
-
-    path = field[-1].lower().replace(' ', '_').split('.')
-    return reduce(getattr, path, obj)
 
 
 def format_json(val):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -328,7 +328,7 @@ class TestCLI(TestCase):
         self.assertEqual(res[1][0][0], ctx['result'].id)
 
     def test_result_list_non_existing_task(self):
-        ctx = ansible_run()
+        ansible_run()
 
         cmd = ara.cli.result.ResultList(None, None)
         parser = cmd.get_parser('test')
@@ -348,7 +348,7 @@ class TestCLI(TestCase):
         self.assertEqual(res[1][0], ctx['result'].id)
 
     def test_result_show_non_existing(self):
-        ctx = ansible_run()
+        ansible_run()
 
         cmd = ara.cli.result.ResultShow(None, None)
         parser = cmd.get_parser('test')
@@ -366,10 +366,10 @@ class TestCLI(TestCase):
         res = cmd.take_action(args)
 
         self.assertEqual(res[1][0], ctx['result'].id)
-        self.assertEqual(res[1][7], ctx['result'].result)
+        self.assertEqual(res[1][-1], json.dumps(ctx['result'].result))
 
     def test_result_show_long_non_existing(self):
-        ctx = ansible_run()
+        ansible_run()
 
         cmd = ara.cli.result.ResultShow(None, None)
         parser = cmd.get_parser('test')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -24,67 +24,6 @@ class TestUtils(TestCase):
         m.db.session.remove()
         m.db.drop_all()
 
-    def test_fields_from_iter(self):
-        fields = (
-            ('Field 1',),
-            ('Field 2', 'field2'),
-            ('Field 3', 'field3.value'),
-        )
-
-        items = [
-            Mock(field_1='value 1', field2='value 2',
-                 field3=Mock(value='value 3')),
-        ]
-
-        res = u.fields_from_iter(fields, items)
-
-        self.assertEqual(res,
-                         (('Field 1', 'Field 2', 'Field 3'),
-                          [['value 1', 'value 2', 'value 3']]))
-
-    def test_fields_from_iter_xform(self):
-        fields = (
-            ('Field 1',),
-            ('Field 2', 'field2'),
-        )
-
-        items = [
-            Mock(field_1='value 1', field2='value 2'),
-        ]
-
-        res = u.fields_from_iter(fields, items,
-                                 xforms={'Field 2': lambda x: x.upper()})
-
-        self.assertEqual(res,
-                         (('Field 1', 'Field 2'), [['value 1', 'VALUE 2']]))
-
-    def test_fields_from_object(self):
-        fields = (
-            ('Field 1',),
-            ('Field 2', 'field2'),
-        )
-
-        obj = Mock(field_1='value 1', field2='value 2')
-
-        res = u.fields_from_object(fields, obj)
-
-        self.assertEqual(res,
-                         (('Field 1', 'Field 2'), ['value 1', 'value 2']))
-
-    def test_fields_from_object_xform(self):
-        fields = (
-            ('Field 1',),
-            ('Field 2', 'field2'),
-        )
-
-        obj = Mock(field_1='value 1', field2='value 2')
-
-        res = u.fields_from_object(fields, obj,
-                                   xforms={'Field 2': lambda x: x.upper()})
-
-        self.assertEqual(res,
-                         (('Field 1', 'Field 2'), ['value 1', 'VALUE 2']))
-
     def test_status_to_query(self):
         res = u.status_to_query('ok')
         self.assertEqual(res, {'status': 'ok'})


### PR DESCRIPTION
This replaces some of the more complex code in ara.utils with the
(hopefully) more obvious ara.fields.Field class, which also brings the
benefit of Jinja2 formatting to our CLI output.  This lets us utilize
jinja2 filters for formatting values for display, which avoids
code duplication and generally makes for cleaner display code.

This code also differentiates the output provided by the "list" and
"show" commands in several places such that the "show" command display
more information that is available in the corresponding "list"
command.